### PR TITLE
[WIP] v 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11894,6 +11894,16 @@
         "shallowequal": "^1.0.1"
       }
     },
+    "react-tabs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-2.3.0.tgz",
+      "integrity": "sha512-pYaefgVy76/36AMEP+B8YuVVzDHa3C5UFZ3REU78zolk0qMxEhKvUFofvDCXyLZwf0RZjxIfiwok1BEb18nHyA==",
+      "dev": true,
+      "requires": {
+        "classnames": "^2.2.0",
+        "prop-types": "^15.5.0"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -15047,7 +15057,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "react-tabs": "^2.3.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -147,6 +147,7 @@ class App extends Component {
 
   renderCompilationResult(fileName, result) {
     if(result.status == 'inProgress') {
+      // Show an icon which tells "it's in progress"
       return ''
     } else if(result.status == 'success') {  
       return (

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import "./remix-api";
-import { Button, Radio, Popup, Icon, Tab } from 'semantic-ui-react'
-import { Container } from 'semantic-ui-react'
+import { Button, Radio, Popup, Icon} from 'semantic-ui-react'
 import { Helmet } from 'react-helmet'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
+import '../node_modules/react-tabs/style/react-tabs.css'
 import { ballot } from './example-contracts'
 
 var extension = new window.RemixExtension()
@@ -193,22 +194,27 @@ class App extends Component {
         <div>
           <span style={{color: 'green'}}>Succeeded!</span>
           <p />
-          <div>
-          <Button toggle active={this.state.showedResult === 'bytecode'} onClick={() => this.handleToggleClick('bytecode')}>
-            bytecode
-          </Button>
-          <Button toggle active={this.state.showedResult === 'bytecode_runtime'} onClick={() => this.handleToggleClick('bytecode_runtime')}>
-            runtime bytecode
-          </Button>
-          <Button toggle active={this.state.showedResult === 'ir'} onClick={() => this.handleToggleClick('ir')}>
-            LLL
-          </Button>
-          </div>
-          <p />
           {this.renderCopyResult()}
-          <Container textAlign='left'>
-            {this.state.showedResult ? <pre>{this.state.compilationResult[this.state.showedResult]}</pre> : null}
-          </Container>
+          <p />
+          <div>
+          <Tabs>
+            <TabList>
+              <Tab>bytecode</Tab>
+              <Tab>runtime bytecode</Tab>
+              <Tab>LLL</Tab>
+            </TabList>
+
+            <TabPanel>
+              <h2>{this.state.compilationResult['bytecode']}</h2>
+            </TabPanel>
+            <TabPanel>
+              <h2>{this.state.compilationResult['bytecode_runtime']}</h2>
+            </TabPanel>
+            <TabPanel>
+              <h2><pre>{this.state.compilationResult['ir']}</pre></h2>
+            </TabPanel>
+        </Tabs>
+        </div>
         </div>
       )
     } else if(result.status == 'failed' && result.column && result.line) {
@@ -246,13 +252,13 @@ class App extends Component {
     return (
       <div style={{ "textAlign": "center" }}>
         <Helmet>
-          <style>{'body { color: white; background-color: #252839; }'}</style>
+          <style>{'body { color: black; background-color: white; }'}</style>
         </Helmet>
         <div style={{ display: "inline" }}>
           <h1 style={{ marginTop: "1em" }}>Vyper Compiler</h1>
           <p>v 0.2.0</p>
         </div>
-        <div style={{ color: "white", background: "#495285", margin: "1em 2em", padding: "1.5em 0" }}>
+        <div style={{ margin: "1em 2em", padding: "1.5em 0" }}>
           <Radio type="radio" name="compile" value="remote" onChange={() => this.setState({ compileDst: "remote" })} checked={this.state.compileDst === 'remote'} label="Remote"/>
           <Popup trigger={<Icon name="question circle" />}
             content="You can use remote compiler"
@@ -268,7 +274,7 @@ class App extends Component {
             <div style={{ "marginTop": "2em" }}>
               <Button disabled={this.state.loading} primary onClick={() => this.onCompileFromRemix()}>
                 Compile
-            </Button>
+              </Button>
             <Popup trigger={<Icon name="question circle" />}>  
                 <div>1. Write vyper code(.vy) in the editor</div>
                 <div>2. Click Compile button</div>

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { Button, Radio, Popup, Icon} from 'semantic-ui-react'
 import { Helmet } from 'react-helmet'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
-import '../node_modules/react-tabs/style/react-tabs.css'
+// import '../node_modules/react-tabs/style/react-tabs.css'
 import { ballot } from './example-contracts'
 
 var extension = new window.RemixExtension()

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import "./remix-api";
-import { Button, Radio, Popup, Icon } from 'semantic-ui-react'
+import { Button, Radio, Popup, Icon, Tab } from 'semantic-ui-react'
 import { Container } from 'semantic-ui-react'
 import { Helmet } from 'react-helmet'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
@@ -246,14 +246,14 @@ class App extends Component {
     return (
       <div style={{ "textAlign": "center" }}>
         <Helmet>
-          <style>{'body { background-color: #F0F3FE; }'}</style>
+          <style>{'body { color: white; background-color: #252839; }'}</style>
         </Helmet>
         <div style={{ display: "inline" }}>
           <h1 style={{ marginTop: "1em" }}>Vyper Compiler</h1>
           <p>v 0.2.0</p>
         </div>
-        <div style={{ background: "white", margin: "1em 2em", padding: "1.5em 0" }}>
-          <Radio type="radio" name="compile" value="remote" onChange={() => this.setState({ compileDst: "remote" })} checked={this.state.compileDst === 'remote'} label="Remote" />
+        <div style={{ color: "white", background: "#495285", margin: "1em 2em", padding: "1.5em 0" }}>
+          <Radio type="radio" name="compile" value="remote" onChange={() => this.setState({ compileDst: "remote" })} checked={this.state.compileDst === 'remote'} label="Remote"/>
           <Popup trigger={<Icon name="question circle" />}
             content="You can use remote compiler"
             basic


### PR DESCRIPTION
## Spec
- [ ] add tabs to show compilation results (bytecode/bytecode_runtime/LLL)
  - [ ] horizontal scroll
  - [ ] "copy" (to clipboard) button
- [ ] change color scheme

## About tab
- "Tab" of react-semantic-ui does not enable each tab's content to include JSX so we can't add horizontal scroller and "copy" button
- commit `2c318a1` uses toggle buttons instead of tab